### PR TITLE
Fix for API token auth

### DIFF
--- a/syndicate/adapters/async.py
+++ b/syndicate/adapters/async.py
@@ -42,7 +42,7 @@ class AsyncAdapter(base.AdapterBase):
 
     def authenticate(self, request):
         if callable(self.auth):
-            return self.auth(request)
+            self.auth(request)
         else:
             request.auth_username, request.auth_password = self.auth
         # TODO: Replace with gen.maybe_future in tornado 3.3


### PR DESCRIPTION
Removed a breakpoint from HeaderAuth callable.
Modified authenticate to return a future after both auth mechenisims are
evaluated.
