### PR TITLE
Fixes #3

### DIFF
--- a/syndicate/adapters/async.py
+++ b/syndicate/adapters/async.py
@@ -76,8 +76,10 @@ class AsyncAdapter(base.AdapterBase):
             concurrent.chain_future(fetch_result, user_result)
         else:
             native_resp = fetch_result.result()
+            content = None
             try:
-                content = self.serializer.decode(native_resp.body.decode())
+                if native_resp.body and len(native_resp.body):
+                    content = self.serializer.decode(native_resp.body.decode())
             except Exception:
                 user_result.set_exc_info(sys.exc_info())
             else:

--- a/syndicate/adapters/sync.py
+++ b/syndicate/adapters/sync.py
@@ -35,8 +35,10 @@ class SyncAdapter(base.AdapterBase):
         timeout = self.request_timeout if timeout is None else timeout
         resp = self.session.request(method, url, data=data, params=query,
                                     timeout=timeout)
+        content = None
         try:
-            content = self.serializer.decode(resp.content.decode())
+            if resp.content and len(resp.content):
+                content = self.serializer.decode(resp.content.decode())
         except Exception as e:
             error = e
             content = None

--- a/syndicate/client.py
+++ b/syndicate/client.py
@@ -33,6 +33,8 @@ class Service(object):
         if response.error:
             raise response.error
         content = response.content
+        if not content:
+            return None
         if not content['success']:
             raise ResponseError(content)
         return content.get('data')
@@ -40,6 +42,8 @@ class Service(object):
     @staticmethod
     def default_meta_getter(response):
         content = response.content
+        if not content:
+            return None
         return content.get('meta')
 
     def __init__(self, uri=None, urn=None, auth=None, serializer='json',

--- a/test/test_no_response.py
+++ b/test/test_no_response.py
@@ -1,0 +1,97 @@
+from unittest import mock
+from unittest import TestCase
+
+
+class TestAsyncAdapter204Response(TestCase):
+    def _run_test(self, http_code, body=None):
+        resp_mock = mock.MagicMock(**{
+            "code": mock.PropertyMock(),
+            "headers": mock.PropertyMock(),
+            "body": mock.PropertyMock()
+        })
+        resp_mock.code = http_code
+        resp_mock.headers = None
+        resp_mock.body = body
+
+        fetch_mock = mock.MagicMock(**{
+            "exception.return_value": False,
+            "result.return_value": resp_mock
+        })
+
+        user_result = mock.MagicMock()
+        with mock.patch('tornado.httpclient.AsyncHTTPClient'):
+            from syndicate.adapters.async import AsyncAdapter
+            adapter = AsyncAdapter()
+            def filter(obj):
+                return obj
+            adapter.ingress_filter = filter
+            adapter.on_request_done(user_result, fetch_mock)
+            from syndicate.adapters.base import Response
+
+            r = Response(http_code=http_code, headers=None,
+                          content=None, error=None, extra=resp_mock)
+            user_result.set_result.assert_called_once_with(r)
+
+    def test_204_response(self):
+        self._run_test(204)
+
+    def test_no_response(self):
+        self._run_test(200, b"")
+
+
+class TestSyncAdapter204Response(TestCase):
+    def _run_test(self, http_code, body=None):
+        response_mock = mock.MagicMock(**{
+            "status_code": mock.PropertyMock(),
+            "content": mock.PropertyMock(),
+        })
+        response_mock.status_code = http_code
+        response_mock.content = body
+        session_mock = mock.MagicMock(**{
+            "request.return_value": response_mock
+        })
+        with mock.patch('requests.Session', return_value=session_mock):
+            from syndicate.adapters.sync import SyncAdapter
+
+            adapter = SyncAdapter()
+            def filter(obj):
+                return obj
+
+            adapter.ingress_filter = filter
+            result = adapter.request('DELETE', url='/foo/')
+            self.assertEqual(result.http_code, http_code)
+            self.assertIsNone(result.error)
+            self.assertIsNone(result.content)
+            return result
+
+    def test_204_response(self):
+        self._run_test(204)
+
+    def test_empty_response(self):
+        self._run_test(200, b"")
+
+
+class TestClient204Response(TestCase):
+    def test_client_service_204_default_data_getter(self):
+        from syndicate.adapters.base import Response
+
+        r = Response(http_code=204, headers=None,
+                          content=None, error=None, extra=None)
+
+        from syndicate.client import Service
+        s = Service(uri='http://test', urn="/api/v1")
+
+        value = s.default_data_getter(r)
+        self.assertIsNone(value)
+
+    def test_client_service_204_default_meta_getter(self):
+        from syndicate.adapters.base import Response
+
+        r = Response(http_code=204, headers=None,
+                          content=None, error=None, extra=None)
+
+        from syndicate.client import Service
+        s = Service(uri='http://test', urn="/api/v1")
+
+        value = s.default_meta_getter(r)
+        self.assertIsNone(value)


### PR DESCRIPTION
Handle empty or 0 length HTTP responses properly.
Prevent trying to decode invalid JSON on a successful response.
Added unit tests for empty and 0 length responses.

I think this is what you were looking for in the re-factored solution. 
Let me know if you want any more changes.
